### PR TITLE
Update dehydrated

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -402,6 +402,9 @@ init_system() {
   # Read account information or request from CA if missing
   if [[ -e "${ACCOUNT_KEY_JSON}" ]]; then
     ACCOUNT_ID="$(cat "${ACCOUNT_KEY_JSON}" | get_json_int_value id)"
+    if [[ -z ${ACCOUNT_ID} ]]; then
+      ACCOUNT_ID="$(cat "${ACCOUNT_KEY_JSON}" | get_json_string_value id)"
+    fi
     if [[ ${API} -eq 1 ]]; then
       ACCOUNT_URL="${CA_REG}/${ACCOUNT_ID}"
     else


### PR DESCRIPTION
Add support for non-int (e.g. hex) account identifiers. The RFC draft does not mandate the account identifier to be a decimal integer